### PR TITLE
[feaature / fix ] netlify 배포시 img에 alt 속성 없어서 배포실패에 대한 에러 해결

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,15 +5,18 @@ import Box from "./components/Box";
 const choice = {
   rock: {
     name: "rock",
-    img: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSY24vXcxwnkJbGJi_nQWV6VNzVronsPHLtUk_dmCc_qHt-sJ9Qziuc82Yp2yOwVPNeOFM&usqp=CAU"
+    img: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSY24vXcxwnkJbGJi_nQWV6VNzVronsPHLtUk_dmCc_qHt-sJ9Qziuc82Yp2yOwVPNeOFM&usqp=CAU",
+    desc: "바위"
   },
   scissors: {
     name: "scissors",
-    img: "https://assets.katogroup.eu/i/katogroup/VT8-0919-24_02_victorinox"
+    img: "https://assets.katogroup.eu/i/katogroup/VT8-0919-24_02_victorinox",
+    desc: "가위"
   },
   paper:{
     name: "paper",
-    img:"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRQVTP3dHJXp9MeXJzdSTg0A1jM6ljyaDvgEw&s"
+    img:"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRQVTP3dHJXp9MeXJzdSTg0A1jM6ljyaDvgEw&s",
+    desc: "보"
   }
 }
 

--- a/src/components/Box.js
+++ b/src/components/Box.js
@@ -6,7 +6,7 @@ const Box = (props) => {
   return (
     <div className="box">
         <h1>{props.title}</h1>
-        <img className="item-img" src={props.item && props.item.img} />
+        <img className="item-img" src={props.item && props.item.img} alt={props.item && props.item.desc}/>
         <h2>WIN</h2>
     </div>
   )


### PR DESCRIPTION
#4
- [x] netlify 배포 오류 해결

배포 문제
- img 태그에 alt 속성이 없어 에러가 발생했다

해결 방법
- choice 객체에 desc 속성 값을 추가하여 버튼 클릭시 props로 넘겨 img 태그의 alt 속성에 적용 하는 방식으로 코드를 수정했다

