### PR TITLE
[feat] 가위바위보 게임을 클래스 컴포넌트로 변경하면서 BoxClass 상태관리 문제 해결

### DIFF
--- a/src/components/Box.js
+++ b/src/components/Box.js
@@ -4,11 +4,7 @@ const Box = (props) => {
   let result = '';
   console.log("props: ", props);
   if ( props.title === "Computer" && props.result !== "draw" && props.result !== "" ) { 
-    // if (props.result === "win") {
-    //     result = "lose";
-    // } else if (props,result === "lose")  {
-    //     result = "win"
-    // }
+  
     result = props.result === "win" ? "loose" : "win";
   } else {
     result = props.result;

--- a/src/components/BoxClass.js
+++ b/src/components/BoxClass.js
@@ -1,27 +1,31 @@
 import React, { Component } from "react";
 
 export default class BoxClass extends Component {
-  constructor() {
-    super();
-    this.result = "";
+  constructor(props) {
+    super(props);
+    this.state = {
+      result: "",
+    };
   }
-  getResult = () => {
+
+  static getDerivedStateFromProps(nextProps, prevState) {
     if (
-      this.props.title === "Computer" &&
-      this.props.result !== "tie" &&
-      this.props.result !== ""
+      nextProps.title === "Computer" &&
+      nextProps.result !== "tie" &&
+      nextProps.result !== ""
     ) {
-      // 카드가 computer카드인가? && 결과가 비긴건 아닌가? && this.props.result에 값이 있는가?
-      this.result = this.props.result === "win" ? "lose" : "win";
-    } else {
-      // 위의 경우가 아니라면 this.props&nbsp;로 전달된 결과를 그대로 쓴다.
-      this.result = this.props.result;
+      return {
+        result: nextProps.result === "win" ? "lose" : "win",
+      };
     }
-  };
+    return {
+      result: nextProps.result,
+    };
+  }
+
   render() {
-    this.getResult();
     return (
-      <div className={`box ${this.result}`}>
+      <div className={`box ${this.state.result}`}>
         <h1>{this.props.title}</h1>
         <h2 data-testid="item-name">
           {this.props.item && this.props.item.name}
@@ -30,7 +34,7 @@ export default class BoxClass extends Component {
           className="item-img"
           src={this.props.item && this.props.item.img}
         />
-        <h2>{this.result}</h2>
+        <h2>{this.state.result}</h2>
       </div>
     );
   }

--- a/src/components/BoxClass.js
+++ b/src/components/BoxClass.js
@@ -30,10 +30,7 @@ export default class BoxClass extends Component {
         <h2 data-testid="item-name">
           {this.props.item && this.props.item.name}
         </h2>
-        <img
-          className="item-img"
-          src={this.props.item && this.props.item.img}
-        />
+        <img className="item-img" src={this.props.item && this.props.item.img} />
         <h2>{this.state.result}</h2>
       </div>
     );

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import "./index.css";
-import App from "./App";
+// import App from "./App";
+import AppClass from "./App"; // 추가된 import 구문
 import reportWebVitals from "./reportWebVitals";
-import AppClass from "./AppClass";
+
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import "./index.css";
 // import App from "./App";
-import AppClass from "./App"; // 추가된 import 구문
+import AppClass from "./App"; 
 import reportWebVitals from "./reportWebVitals";
 
 
@@ -12,8 +12,4 @@ ReactDOM.render(
   </React.StrictMode>,
   document.getElementById("root")
 );
-
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
 reportWebVitals();


### PR DESCRIPTION
#18
- [x] 가위바위보 게임을 클래스 컴포넌트로 변경하면서 BoxClass 상태관리 문제 해결

BoxClass 컴포넌트에서 this.result를 상태로 관리하지 않고, 메서드에서 직접 값을 수정하고 있었다.
this.result는 render 메서드가 호출될 때마다 매번 초기화되므로
result를 state로 관리하거나, 컴포넌트가 전달받은 props를 바로 사용할 수 있다
```
import React, { Component } from "react";

export default class BoxClass extends Component {
  constructor(props) {
    super(props);
    this.state = {
      result: "",
    };
  }

  static getDerivedStateFromProps(nextProps, prevState) {
    if (
      nextProps.title === "Computer" &&
      nextProps.result !== "tie" &&
      nextProps.result !== ""
    ) {
      return {
        result: nextProps.result === "win" ? "lose" : "win",
      };
    }
    return {
      result: nextProps.result,
    };
  }

  render() {
    return (
      <div className={`box ${this.state.result}`}>
        <h1>{this.props.title}</h1>
        <h2 data-testid="item-name">
          {this.props.item && this.props.item.name}
        </h2>
        <img
          className="item-img"
          src={this.props.item && this.props.item.img}
        />
        <h2>{this.state.result}</h2>
      </div>
    );
  }
}
```
